### PR TITLE
Fix log function definition

### DIFF
--- a/webroot/script.js
+++ b/webroot/script.js
@@ -317,6 +317,15 @@ function getRootLabel() {
     return 'ROOT';
 }
 
+function log(message, type = 'info', details = null) {
+    const logsContainer = document.getElementById('logsContainer');
+
+    if (!logsContainer) {
+        const method = type === 'error' ? 'error' : 'log';
+        console[method](`[${type}] ${message}`, details ?? '');
+        return;
+    }
+
     const icons = {
         info: '🔷',
         success: '✅',


### PR DESCRIPTION
## Summary
- define the `log` helper function that handles missing container fallback to console
- ensure logging continues to render entries without syntax errors when logs container is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ffa5b11883278881eeff09838c82