### PR TITLE
Escape shell variables in post-fs script template

### DIFF
--- a/webroot/script.js
+++ b/webroot/script.js
@@ -58,7 +58,7 @@ function escapeHTML(value) {
 function jsStringEscape(value) {
     return String(value)
         .replace(/\\/g, '\\\\')
-        .replace(/'/g, '\\'')
+        .replace(/'/g, "\\'")
         .replace(/\n/g, '\\n')
         .replace(/\r/g, '\\r');
 }
@@ -317,6 +317,15 @@ function getRootLabel() {
     return 'ROOT';
 }
 
+function log(message, type = 'info', details = null) {
+    const logsContainer = document.getElementById('logsContainer');
+
+    if (!logsContainer) {
+        const method = type === 'error' ? 'error' : 'log';
+        console[method](`[${type}] ${message}`, details ?? '');
+        return;
+    }
+
     const icons = {
         info: '🔷',
         success: '✅',
@@ -516,8 +525,8 @@ function renderApps() {
         const appName = escapeHTML(app.name);
         const safeDir = escapeHTML(app.removeTarget);
         const systemInfoMessage = STATE.rootType
-            ? Se aplicará <strong></strong> sobre 
-            : Pendiente de root • ;
+            ? `Se aplicará <code>${escapeHTML(methodLabel)}</code> sobre <code>${safeDir || safePath}</code>`
+            : 'Pendiente de root • Ejecuta manualmente el script desde la pestaña Acciones';
         const pathForJS = jsStringEscape(app.path);
         const nameForJS = jsStringEscape(app.name);
         const appType = app.type === 'system' ? '🔧 Sistema' : '👤 Usuario';
@@ -560,7 +569,7 @@ function renderApps() {
                 ${app.action === 'remove' ? `
                 <div style="margin-top: 0.75rem; padding: 0.5rem; background: var(--bg-secondary); border-radius: var(--radius-sm); text-align: center;">
                     <small style="color: var(--text-secondary);">
-                        \
+                        ${systemInfoMessage}
                     </small>
                 </div>` : ''}
             `;
@@ -1003,7 +1012,7 @@ apply_list() {
   local suffix="$2"
   [ -n "$list" ] || return 0
   for target in $list; do
-    local dest="$MODDIR${target}${suffix}"
+    local dest="$MODDIR\${target}\${suffix}"
     local parent="$(dirname "$dest")"
     mkdir -p "$parent"
     if [ "$suffix" = ".remove" ]; then


### PR DESCRIPTION
## Summary
- escape the post-fs-data template so shell variables remain literal when written

## Testing
- node --check webroot/script.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ffa5b11883278881eeff09838c82