### PR TITLE
Add clipboard export button for logs

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -98,12 +98,21 @@
                         <div class="section-heading">
                             <h2>Registro de Eventos</h2>
                         </div>
-                        <button class="btn btn-secondary" id="clearLogsBtn">
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                                <path d="M6 18L18 6M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                            </svg>
-                            Limpiar
-                        </button>
+                        <div class="log-actions">
+                            <button class="btn btn-secondary" id="copyLogsBtn">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                                    <rect x="9" y="7" width="11" height="13" rx="1.5" stroke="currentColor" stroke-width="2"/>
+                                    <path d="M5 16V5.5C5 4.67157 5.67157 4 6.5 4H15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                </svg>
+                                Copiar
+                            </button>
+                            <button class="btn btn-secondary" id="clearLogsBtn">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                                    <path d="M6 18L18 6M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                </svg>
+                                Limpiar
+                            </button>
+                        </div>
                     </div>
                     <div class="logs-container" id="logsContainer"></div>
                 </div>

--- a/webroot/style.css
+++ b/webroot/style.css
@@ -515,6 +515,16 @@ body {
     font-size: 0.875rem;
 }
 
+.log-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.log-actions .btn {
+    flex: 1 0 auto;
+}
+
 .log-entry {
     padding: 0.5rem;
     border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- add a clipboard button to the logs header so users can copy all entries
- implement a clipboard helper that composes readable log lines and handles fallbacks when navigator.clipboard is unavailable
- tweak the logs section layout styles to accommodate the new actions row

## Testing
- node --check webroot/script.js

------
https://chatgpt.com/codex/tasks/task_e_68e1ffa5b11883278881eeff09838c82